### PR TITLE
Add parameter for AdvertiseAddress

### DIFF
--- a/config_defaults.json
+++ b/config_defaults.json
@@ -31,6 +31,7 @@
   },
   "restAPI": {
     "bindAddress": "localhost:9892",
+    "advertiseAddress": "",
     "debugRequestLoggerEnabled": false
   },
   "profiling": {

--- a/core/participation/component.go
+++ b/core/participation/component.go
@@ -144,7 +144,12 @@ func run() error {
 
 		ctxRegister, cancelRegister := context.WithTimeout(ctx, 5*time.Second)
 
-		if err := deps.NodeBridge.RegisterAPIRoute(ctxRegister, APIRoute, ParamsRestAPI.BindAddress); err != nil {
+		advertisedAddress := ParamsRestAPI.BindAddress
+		if ParamsRestAPI.AdvertiseAddress != "" {
+			advertisedAddress = ParamsRestAPI.AdvertiseAddress
+		}
+
+		if err := deps.NodeBridge.RegisterAPIRoute(ctxRegister, APIRoute, advertisedAddress); err != nil {
 			CoreComponent.LogErrorfAndExit("Registering INX api route failed: %s", err)
 		}
 

--- a/core/participation/params.go
+++ b/core/participation/params.go
@@ -13,10 +13,14 @@ type ParametersParticipation struct {
 	} `name:"db"`
 }
 
-// ParametersRestAPI contains the definition of the parameters used by REST API.
+// ParametersRestAPI contains the definition of the parameters used by the Participation HTTP server.
 type ParametersRestAPI struct {
 	// BindAddress defines the bind address on which the Participation HTTP server listens.
 	BindAddress string `default:"localhost:9892" usage:"the bind address on which the Participation HTTP server listens"`
+
+	// AdvertiseAddress defines the address of the Participation HTTP server which is advertised to the INX Server (optional).
+	AdvertiseAddress string `default:"" usage:"the address of the Participation HTTP server which is advertised to the INX Server (optional)"`
+
 	// DebugRequestLoggerEnabled defines whether the debug logging for requests should be enabled
 	DebugRequestLoggerEnabled bool `default:"false" usage:"whether the debug logging for requests should be enabled"`
 }

--- a/documentation/docs/configuration.md
+++ b/documentation/docs/configuration.md
@@ -146,10 +146,11 @@ Example:
 
 ## <a id="restapi"></a> 5. RestAPI
 
-| Name                      | Description                                                     | Type    | Default value    |
-| ------------------------- | --------------------------------------------------------------- | ------- | ---------------- |
-| bindAddress               | The bind address on which the Participation HTTP server listens | string  | "localhost:9892" |
-| debugRequestLoggerEnabled | Whether the debug logging for requests should be enabled        | boolean | false            |
+| Name                      | Description                                                                                   | Type    | Default value    |
+| ------------------------- | --------------------------------------------------------------------------------------------- | ------- | ---------------- |
+| bindAddress               | The bind address on which the Participation HTTP server listens                               | string  | "localhost:9892" |
+| advertiseAddress          | The address of the Participation HTTP server which is advertised to the INX Server (optional) | string  | ""               |
+| debugRequestLoggerEnabled | Whether the debug logging for requests should be enabled                                      | boolean | false            |
 
 Example:
 
@@ -157,6 +158,7 @@ Example:
   {
     "restAPI": {
       "bindAddress": "localhost:9892",
+      "advertiseAddress": "",
       "debugRequestLoggerEnabled": false
     }
   }


### PR DESCRIPTION
This PR introduces the `AdvertiseAddress` config parameter, which simplifies the setup in some private network environments.